### PR TITLE
Switched image from 'ubuntu' to 'python'

### DIFF
--- a/ksm-z-integration-docker/index.json
+++ b/ksm-z-integration-docker/index.json
@@ -33,6 +33,6 @@
     "hidefinish": true
   },
   "backend": {
-    "imageid": "ubuntu"
+    "imageid": "python"
   }
 }


### PR DESCRIPTION
I think this will solve the crippling problem of seeing this on startup: 
`ubuntu:~$ pip3 install keeper-secrets-manager-cli && \ apt install mysql-client-core-8.0
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.`