### PR TITLE
fix(ksm-cli): correct record notes retrieval and document profile import

### DIFF
--- a/ksm-cli/step1.md
+++ b/ksm-cli/step1.md
@@ -46,6 +46,35 @@ ksm profile init --token XX:XXXX
 
 **✅ Expected Output**: Added profile _default to INI config file...
 
+## Alternative: Import an Existing Configuration
+
+A One-Time Access Token can only be redeemed once. If you already have a Base64 KSM configuration — exported from another machine with `ksm profile export`, or issued to you by an administrator — import it directly instead of using a token:
+
+```bash
+ksm profile import [BASE64_CONFIG]
+```
+`ksm profile import [BASE64_CONFIG]`{{copy}}
+
+Import into a named profile rather than `_default`:
+
+```bash
+ksm profile import --profile-name production [BASE64_CONFIG]
+```
+`ksm profile import --profile-name production [BASE64_CONFIG]`{{copy}}
+
+Repeat with different profile names to keep several applications in one `keeper.ini` — an existing file is merged, not overwritten.
+
+**💡 Importing from a file**: `ksm profile import` expects the Base64 string itself, not a file path. If your configuration is stored in a file, pass its contents in. The `tr` command strips any line wrapping or trailing newline:
+
+```bash
+ksm profile import "$(tr -d '\n\r' < /path/to/config.b64)"
+```
+`ksm profile import "$(tr -d '\n\r' < /path/to/config.b64)"`{{copy}}
+
+**✅ Expected Output**: `Imported config saved to profile _default at ...`, plus a notice that permissions were set to `0600` (owner-only access).
+
+**🔒 Security Note**: A configuration passed as a command-line argument is visible in your shell history and in `ps` output. For automation, prefer the `KSM_CONFIG` environment variable instead (covered in Step 4).
+
 ## Verify Configuration
 
 After initialization, verify your profile was created:

--- a/ksm-cli/step2.md
+++ b/ksm-cli/step2.md
@@ -66,6 +66,19 @@ ksm secret get [UID] --field [FIELD_NAME]
 ```
 `ksm secret get [UID] --field [FIELD_NAME]`{{copy}}
 
+### Get Record Notes
+
+Record notes are **not** a field. They are a record-level property, so `--field notes` fails with `Cannot find the field notes in record ...`. Use a JSONPath query instead:
+
+```bash
+ksm secret get [UID] --query notes --raw
+```
+`ksm secret get [UID] --query notes --raw`{{copy}}
+
+**💡 Why `--raw`?**: Without it the value is returned JSON-encoded, wrapped in double quotes, which is awkward when assigning it to a variable.
+
+**⚠️ Watch Out**: `--field` matches field labels first, then field types. If a record happens to have a custom field *labeled* "notes", then `--field notes` returns that custom field's value instead of the record notes, with no error to warn you.
+
 ## Search for Secrets
 
 Search for secrets by title using regex pattern matching:

--- a/ksm-cli/step4.md
+++ b/ksm-cli/step4.md
@@ -69,7 +69,7 @@ echo "Password retrieved: $MY_PASSWORD"
 **✅ Expected Output**: Shows the actual password from your secret.
 
 ### Get Other Fields Using Notation
-Common field names: `login`, `password`, `url`, `notes`
+Common field types: `login`, `password`, `url`
 
 ```bash
 export MY_USERNAME=$(ksm secret notation keeper://[RECORD_UID]/field/login)
@@ -78,6 +78,20 @@ export MY_URL=$(ksm secret notation keeper://[RECORD_UID]/field/url)
 `export MY_USERNAME=$(ksm secret notation keeper://[RECORD_UID]/field/login)`{{copy}}
 
 **💡 Pro Tip**: Use `ksm secret get [UID]` first to see all available field names for a record.
+
+### Get Record Notes, Title, and Type Using Notation
+
+`notes`, `title`, and `type` are record-level **selectors**, not fields. They replace the `field/[field_name]` portion of the notation rather than appearing inside it:
+
+```bash
+export MY_NOTES=$(ksm secret notation keeper://[RECORD_UID]/notes)
+export MY_TITLE=$(ksm secret notation keeper://[RECORD_UID]/title)
+```
+`export MY_NOTES=$(ksm secret notation keeper://[RECORD_UID]/notes)`{{copy}}
+
+**⚠️ Common Mistake**: `keeper://[UID]/field/notes` does **not** work. Notation looks for a *field* named or typed "notes", which standard record types do not have. Use `keeper://[UID]/notes` instead.
+
+**📝 Note**: The `encryptedNotes` record type also has a genuine field of type `note` (singular), reachable as `keeper://[UID]/field/note`. That is separate from the record-level `notes` property that every record has.
 
 ## File Operations
 


### PR DESCRIPTION
## Summary

Fixes incorrect guidance on retrieving record notes in the KSM CLI tutorial, and documents `ksm profile import`.

- **step4** — removed `notes` from the list of notation field types (it was wrong) and added a section for the record-level `notes` / `title` / `type` selectors, which replace the `field/[name]` segment rather than nesting inside it. Also calls out the `encryptedNotes` field type `note` (singular) as a separate thing from record notes.
- **step2** — added "Get Record Notes" using `ksm secret get [UID] --query notes --raw`, with a warning that `--field notes` silently resolves a custom field *labeled* "notes" when one exists.
- **step1** — documented `ksm profile import` for an already-redeemed Base64 config: named profiles, importing from a file (the argument is a string, not a path), and the argv/shell-history exposure caveat.

## Context

The tutorial presented record notes as both a `--field` target and a `field/notes` notation key. Neither works:

- The CLI's `--field` lookup searches only the record's `fields` and `custom` arrays (by label, then type). Notes are a record-level property, a sibling of those arrays, so `--field notes` errors with `Cannot find the field notes in record ...`.
- `get_notation` handles `type`, `title` and `notes` as top-level selectors, so the correct form is `keeper://[UID]/notes`. This is covered by the SDK's own notation test.

Verified against `secrets-manager` @ `origin/master`. Documentation only, no scenario scripts or `index.json` touched.